### PR TITLE
bugfix: drop vendored version for uvc

### DIFF
--- a/eye-hal/Cargo.toml
+++ b/eye-hal/Cargo.toml
@@ -15,7 +15,7 @@ bitflags = "2.5.0"
 v4l = "0.14.0"
 
 [target.'cfg(target_os="windows")'.dependencies]
-uvc = { version = "0.2.0", features = ["vendor"] }
+uvc = "0.2.0"
 
 [target.'cfg(target_os="macos")'.dependencies]
 openpnp_capture = { version = "0.2.4" }


### PR DESCRIPTION
There seem to be an issue with the vedored version of the `uvc` crate, dropping it seems to solve the problem. 
But this change requires `libuvc` native dependency to be installed. Maybe worth adding it somewhere on the README?

More infos on the linked issue below
Fixes #13 
